### PR TITLE
chore(linter): typecheck error on Tour.vue

### DIFF
--- a/src/runtime/components/Tour.vue
+++ b/src/runtime/components/Tour.vue
@@ -630,6 +630,7 @@
     } else {
       // remove the center class
       document.getElementById(parentId)?.classList.remove("nt-center");
+      // @ts-ignore
       popper.value.state.elements.reference = document.querySelector(
         `${getCurrentStep.value.target}`
       );


### PR DESCRIPTION
When using `nuxi typecheck` disable error below: 

```console
node_modules/.pnpm/nuxt-tour@0.0.7_patch_hash=jcl3jif6pbvskhegthr2kfhxfq_@nuxtjs+tailwindcss@6.12.0_rollup@4.16._seikebqj3qi5cmgd4tt27ccwr4/node_modules/nuxt-tour/dist/runtime/components/Tour.vue:633:7 - error TS18047: 'popper.value' is possibly 'null'.

633       popper.value.state.elements.reference = document.querySelector(
          ~~~~~~~~~~~~

node_modules/.pnpm/nuxt-tour@0.0.7_patch_hash=jcl3jif6pbvskhegthr2kfhxfq_@nuxtjs+tailwindcss@6.12.0_rollup@4.16._seikebqj3qi5cmgd4tt27ccwr4/node_modules/nuxt-tour/dist/runtime/components/Tour.vue:633:7 - error TS2322: Type 'Element | null' is not assignable to type 'Element | { getBoundingClientRect: () => ClientRect | DOMRect; contextElement?: Element | undefined; }'.
  Type 'null' is not assignable to type 'Element | { getBoundingClientRect: () => ClientRect | DOMRect; contextElement?: Element | undefined; }'.

633       popper.value.state.elements.reference = document.querySelector(
``` 